### PR TITLE
Updating grunt-sass version to avoid issue with node-sass@1.2.3 dependency

### DIFF
--- a/lib/templates/app/package.json
+++ b/lib/templates/app/package.json
@@ -35,7 +35,7 @@
     "grunt-contrib-jshint": "~0.11.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-karma": "~0.10.1",
-    "grunt-sass": "~0.17.0",
+    "grunt-sass": "~1.1.0",
     "jasmine": "~2.2.0",
     "jasmine-flight": "git://github.com/mo-lon/jasmine-flight.git#579cce7fcc2477ff6c47495c66780d5f5c014d29",
     "jasmine-jquery": "~2.0.6",


### PR DESCRIPTION
Hi Mo,

Found that the DDFlightGenerator generator was packaged with an old grunt-sass version that had a dependency on node-sass 1.2.3 which gave a postinstall error at `npm install` step in the generator.

This seems to do the trick.

Cheers,

Jack Spargo
